### PR TITLE
docs/xenopsd: List the child pages using the children shortcode

### DIFF
--- a/doc/content/xenopsd/design/_index.md
+++ b/doc/content/xenopsd/design/_index.md
@@ -1,3 +1,6 @@
 +++
 title = "Design"
 +++
+
+Design documents for `xenopsd`:
+{{% children %}}

--- a/doc/content/xenopsd/walkthroughs/_index.md
+++ b/doc/content/xenopsd/walkthroughs/_index.md
@@ -6,8 +6,10 @@ linkTitle = "Walk-throughs"
 Let's trace through interesting operations to see how the whole system
 works.
 
-- [Starting a VM](VM.start.md)
-- [Migrating a VM](VM.migrate.md)
+{{% children %}}
+
+Inspiration for other walk-throughs:
+
 - Shutting down a VM and waiting for it to happen
 - A VM wants to reboot itself
 - A disk is hotplugged


### PR DESCRIPTION
Opened for preview on render.com, see the preview environment below.

PS: Here is a preview of the docs with this PR (but the other PRs are not applied):

https://bernhard-xapi-onrender-com-pr-8.onrender.com/xenopsd/walkthroughs/index.html
https://bernhard-xapi-onrender-com-pr-8.onrender.com/xenopsd/design/index.html

##### How this works:

_I configured a fork of this repository for automatic Hugo previews on http://render.com using this blueprint: https://github.com/bernhard-xapi/bernhard-xapi.onrender.com/blob/main/render.yaml. After enabling previews for pull requests , I got this preview site created automatically after opening a local PR in the repository. This is the PR showing the creation of the preview site: https://github.com/bernhard-xapi/xapi/pull/8 (it only supports local pull requests within the repository, so I had to create a local PR for it)_